### PR TITLE
Skip Resource Reconciliation When `Namespace` is Deleted

### DIFF
--- a/internal/controller/namespaceclass_controller.go
+++ b/internal/controller/namespaceclass_controller.go
@@ -87,6 +87,11 @@ func (r *NamespaceClassReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		// The namespace has the label, so for now we'll log the value
 		log.Info("Namespace has a namespaceclass label", "labelValue", labelValue)
 
+		if namespace.DeletionTimestamp != nil {
+			// Namespace is being deleted, skip creating or updating resources
+			return ctrl.Result{}, nil
+		}
+
 		// Check for the NamespaceClass resource with the same name as the label value
 		namespaceClass := &akuityiov1.NamespaceClass{}
 


### PR DESCRIPTION
When a namespace is deleted, the controller logs the following errors:
```
2025-05-07T21:42:21-04:00	ERROR	failed to create resource	{"controller": "namespaceclass", "controllerGroup": "akuity.io", "controllerKind": "NamespaceClass", "NamespaceClass": {"name":"sample"}, "namespace": "", "name": "sample", "reconcileID": "381e01d2-eef9-49ca-88e7-a7ea968fb98c", "resource": {"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"configmap-sample"},"namespace":"default"}, "error": "namespaces \"sample\" not found"}
akuity.io/namespace-class/internal/controller.(*NamespaceClassReconciler).CreateOrUpdateResource
	/home/ian/Documents/akuity/namespace-class/internal/controller/namespaceclass_controller.go:204
akuity.io/namespace-class/internal/controller.(*NamespaceClassReconciler).Reconcile
	/home/ian/Documents/akuity/namespace-class/internal/controller/namespaceclass_controller.go:151
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
2025-05-07T21:42:21-04:00	ERROR	failed to create or update resource	{"controller": "namespaceclass", "controllerGroup": "akuity.io", "controllerKind": "NamespaceClass", "NamespaceClass": {"name":"sample"}, "namespace": "", "name": "sample", "reconcileID": "381e01d2-eef9-49ca-88e7-a7ea968fb98c", "namespaceClass": {"apiVersion": "akuity.io/v1", "kind": "NamespaceClass", "name": "namespaceclass-sample"}, "error": "namespaces \"sample\" not found"}
akuity.io/namespace-class/internal/controller.(*NamespaceClassReconciler).Reconcile
	/home/ian/Documents/akuity/namespace-class/internal/controller/namespaceclass_controller.go:153
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
2025-05-07T21:42:21-04:00	ERROR	Reconciler error	{"controller": "namespaceclass", "controllerGroup": "akuity.io", "controllerKind": "NamespaceClass", "NamespaceClass": {"name":"sample"}, "namespace": "", "name": "sample", "reconcileID": "381e01d2-eef9-49ca-88e7-a7ea968fb98c", "error": "namespaces \"sample\" not found"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/home/ian/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
```

To resolve this issue, we check for a `DeletionTimestamp` on the namespace and return the reconcile loop at this point, skipping create or update steps.