### PR TITLE
Update RBAC and Check for Undefined `NamespaceClass`

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - akuity.io
   resources:
   - namespaceclasses


### PR DESCRIPTION
- Open up permissions for manager's ClusterRole
- If namespace has a label with an undefined `NamespaceClass`, skip